### PR TITLE
A couple of stability updates for when Start encounters an exception

### DIFF
--- a/MassTransit.Host.RabbitMQ/Program.cs
+++ b/MassTransit.Host.RabbitMQ/Program.cs
@@ -30,7 +30,7 @@ namespace MassTransit.Host.RabbitMQ
 					s.WhenStarted(tc => tc.Start());
 					s.WhenStopped(tc => tc.Stop());
 				});
-				x.RunAsLocalService();
+				x.RunAsLocalSystem();
 				
 				x.SetDescription("MassTransit RabbitMQ Service Bus Host");
 				x.SetDisplayName("MassTransitServiceBusHost");

--- a/MassTransit.Host.RabbitMQ/Program.cs
+++ b/MassTransit.Host.RabbitMQ/Program.cs
@@ -30,7 +30,7 @@ namespace MassTransit.Host.RabbitMQ
 					s.WhenStarted(tc => tc.Start());
 					s.WhenStopped(tc => tc.Stop());
 				});
-				x.RunAsLocalSystem();
+				x.RunAsLocalService();
 				
 				x.SetDescription("MassTransit RabbitMQ Service Bus Host");
 				x.SetDisplayName("MassTransitServiceBusHost");

--- a/MassTransit.Host.RabbitMQ/ServiceHost.cs
+++ b/MassTransit.Host.RabbitMQ/ServiceHost.cs
@@ -11,16 +11,12 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the 
 // specific language governing permissions and limitations under the License.
 
-using Castle.Core.Logging;
+using System;
+using System.IO;
+using System.Reflection;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
 using Castle.Windsor.Installer;
-using Magnum.Extensions;
-using MassTransit;
-using System;
-using System.Diagnostics.Eventing.Reader;
-using System.IO;
-using System.Reflection;
 using MassTransit.Host.RabbitMQ.Configuration;
 using NLog;
 

--- a/MassTransit.Host.RabbitMQ/ServiceHost.cs
+++ b/MassTransit.Host.RabbitMQ/ServiceHost.cs
@@ -73,6 +73,7 @@ namespace MassTransit.Host.RabbitMQ
 			catch (Exception e)
 			{
 				logger.Error(e.ToString);
+				throw;
 			}
 		}
 

--- a/MassTransit.Host.RabbitMQ/ServiceHost.cs
+++ b/MassTransit.Host.RabbitMQ/ServiceHost.cs
@@ -18,6 +18,7 @@ using Castle.Windsor.Installer;
 using Magnum.Extensions;
 using MassTransit;
 using System;
+using System.Diagnostics.Eventing.Reader;
 using System.IO;
 using System.Reflection;
 using MassTransit.Host.RabbitMQ.Configuration;
@@ -77,7 +78,7 @@ namespace MassTransit.Host.RabbitMQ
 
 		public void Stop()
 		{
-			_bus.Dispose();
+			if (_bus != null) _bus.Dispose();
 		}
 
 		internal static void RegisterTypes(IWindsorContainer container)


### PR DESCRIPTION
Currently if the service Start method throws an exception, the service will keep running. Trying to stop the service in this condition will show Error 1503: The service did not respond to the start or control request in timely fashion. The problem is that `_bus` was null in this case so `_bus.Dispose()` in the stop method threw an exception.

The expectation is that:
- Stop should not fail, so check for null
- If Start encounters an exception, it should throw so the service fails to start.

Also, I wasn't familiar with why one would run as Local System vs Local Service. I found the best practice is to use Local Service, since it has minimal privileges, whereas Local System is similar to Administrator. Probably better to default to Local Service.
