### PR TITLE
Add exit code to application

### DIFF
--- a/MassTransit.Host.RabbitMQ/Program.cs
+++ b/MassTransit.Host.RabbitMQ/Program.cs
@@ -12,7 +12,6 @@
 // specific language governing permissions and limitations under the License.
 
 using System;
-using Magnum.Extensions;
 using Topshelf;
 
 namespace MassTransit.Host.RabbitMQ

--- a/MassTransit.Host.RabbitMQ/Program.cs
+++ b/MassTransit.Host.RabbitMQ/Program.cs
@@ -11,6 +11,8 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the 
 // specific language governing permissions and limitations under the License.
 
+using System;
+using Magnum.Extensions;
 using Topshelf;
 
 namespace MassTransit.Host.RabbitMQ
@@ -22,7 +24,7 @@ namespace MassTransit.Host.RabbitMQ
 	{
 		static void Main(string[] args)
 		{
-			HostFactory.Run(x =>
+			var exitCode = HostFactory.Run(x =>
 			{
 				x.Service<ServiceHost>(s =>
 				{
@@ -36,10 +38,9 @@ namespace MassTransit.Host.RabbitMQ
 				x.SetDisplayName("MassTransitServiceBusHost");
 				x.SetServiceName("MassTransitServiceBusHost");
 			});
-			 
-
 			//TODO: extra parameter stuff 
 
+			Environment.Exit((int)exitCode);
 		}
 	}
 }


### PR DESCRIPTION
HostFactory.Run returns an exit code that can be returned from the calling application. Returning this from the MassTransit host will help the caller detect problems.
