### PR TITLE
Updating to Masstransit 3

### DIFF
--- a/MassTransit.Host.RabbitMQ.Tests/App.config
+++ b/MassTransit.Host.RabbitMQ.Tests/App.config
@@ -1,6 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<connectionStrings>
-		<add name="Host.RabbitMQConnection" connectionString="endpoint=rabbitmq://test/test; userId=testUser; password=testPassword" />
+		<add name="Host.RabbitMQConnection" connectionString="endpoint=rabbitmq://test/test; queueName=test_queue; userId=testUser; password=testPassword" />
 	</connectionStrings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="RabbitMQ.Client" publicKeyToken="89e7d7c5feba84ce" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.6.3.0" newVersion="3.6.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/MassTransit.Host.RabbitMQ.Tests/MassTransit.Host.RabbitMQ.Tests.csproj
+++ b/MassTransit.Host.RabbitMQ.Tests/MassTransit.Host.RabbitMQ.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MassTransit.Host.RabbitMQ.Tests</RootNamespace>
     <AssemblyName>MassTransit.Host.RabbitMQ.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/MassTransit.Host.RabbitMQ.Tests/ServiceBusConfigTests.cs
+++ b/MassTransit.Host.RabbitMQ.Tests/ServiceBusConfigTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Text;
-using System.Collections.Generic;
-using MassTransit.Host.RabbitMQ.Configuration;
+﻿using MassTransit.Host.RabbitMQ.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace MassTransit.Host.RabbitMQ.Tests
@@ -25,6 +22,7 @@ namespace MassTransit.Host.RabbitMQ.Tests
 
 			Assert.IsNotNull(result);
 			Assert.AreEqual(result.EndpointAddress, "rabbitmq://test/test");
+			Assert.AreEqual(result.QueueName, "test_queue");
 			Assert.AreEqual(result.RabbitMqUserName, "testUser");
 			Assert.AreEqual(result.RabbitMqPassword, "testPassword");
 		}

--- a/MassTransit.Host.RabbitMQ/Configuration/RabbitMQConnectionStringParser.cs
+++ b/MassTransit.Host.RabbitMQ/Configuration/RabbitMQConnectionStringParser.cs
@@ -48,6 +48,9 @@ namespace MassTransit.Host.RabbitMQ.Configuration
 				case "endpoint" :
 					config.EndpointAddress = settingValue;
 					break;
+				case "queuename":
+					config.QueueName = settingValue;
+					break;
 				case "userid" :
 					config.RabbitMqUserName = settingValue;
 					break;

--- a/MassTransit.Host.RabbitMQ/Configuration/ServiceBusConfig.cs
+++ b/MassTransit.Host.RabbitMQ/Configuration/ServiceBusConfig.cs
@@ -23,6 +23,7 @@ namespace MassTransit.Host.RabbitMQ.Configuration
 	internal class ServiceBusConfig
 	{
 		public string EndpointAddress { get; set; }
+		public string QueueName { get; set; }
 		public string RabbitMqUserName { get; set; }
 		public string RabbitMqPassword { get; set; }
 

--- a/MassTransit.Host.RabbitMQ/MassTransit.Host.RabbitMQ.csproj
+++ b/MassTransit.Host.RabbitMQ/MassTransit.Host.RabbitMQ.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MassTransit.Host.RabbitMQ</RootNamespace>
     <AssemblyName>MassTransit.Host.RabbitMQ</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -34,39 +35,45 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.2.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Castle.Core.3.2.0\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Castle.Windsor, Version=3.2.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Castle.Windsor.3.2.1\lib\net45\Castle.Windsor.dll</HintPath>
+    <Reference Include="Castle.Windsor, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Windsor.3.3.0\lib\net45\Castle.Windsor.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Magnum, Version=2.1.2.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Magnum.2.1.2\lib\NET40\Magnum.dll</HintPath>
+    <Reference Include="Magnum, Version=2.1.3.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Magnum.2.1.3\lib\NET40\Magnum.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="MassTransit, Version=2.9.0.0, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MassTransit.2.9.5\lib\net40\MassTransit.dll</HintPath>
+    <Reference Include="MassTransit, Version=3.3.1.0, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
+      <HintPath>..\packages\MassTransit.3.3.5\lib\net452\MassTransit.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="MassTransit.Transports.RabbitMq, Version=2.9.0.0, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MassTransit.RabbitMQ.2.9.5\lib\net40\MassTransit.Transports.RabbitMq.dll</HintPath>
+    <Reference Include="MassTransit.RabbitMqTransport, Version=3.3.1.0, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
+      <HintPath>..\packages\MassTransit.RabbitMQ.3.3.5\lib\net452\MassTransit.RabbitMqTransport.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="MassTransit.WindsorIntegration, Version=2.9.0.0, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\MassTransit.CastleWindsor.2.9.5\lib\net40\MassTransit.WindsorIntegration.dll</HintPath>
+    <Reference Include="MassTransit.WindsorIntegration, Version=3.3.1.0, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
+      <HintPath>..\packages\MassTransit.CastleWindsor.3.3.5\lib\net452\MassTransit.WindsorIntegration.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="NewId, Version=2.1.3.0, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
+      <HintPath>..\packages\NewId.2.1.3\lib\net45\NewId.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NLog">
-      <HintPath>..\packages\NLog.3.1.0.0\lib\net45\NLog.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.2.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RabbitMQ.Client.3.2.1\lib\net30\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.3.5\lib\net45\NLog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="RabbitMQ.Client, Version=3.6.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\packages\RabbitMQ.Client.3.6.2\lib\net45\RabbitMQ.Client.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -76,9 +83,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Topshelf, Version=3.1.122.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Topshelf.3.1.3\lib\net40-full\Topshelf.dll</HintPath>
+    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.4.0.1\lib\net452\Topshelf.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/MassTransit.Host.RabbitMQ/MassTransit.Host.RabbitMQ.nuspec
+++ b/MassTransit.Host.RabbitMQ/MassTransit.Host.RabbitMQ.nuspec
@@ -2,28 +2,28 @@
 <package >
 	<metadata>
 		<id>MassTransit.Host.RabbitMQ</id>
-		<version>1.7.0</version>
+		<version>2.0.0</version>
 		<title>MassTransit.Host.RabbitMQ</title>
 		<authors>Ron Griffin</authors>
 		<owners>rongriffin@gmail.com</owners>
 		<licenseUrl>http://www.apache.org/licenses/LICENSE-2.0.html</licenseUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>Service Bus Host for Mass Transit services using RabbitMQ</description>
-		<releaseNotes>Adding exit code to play nice with batch install</releaseNotes>
+		<releaseNotes>Updating to MassTransit 3 and upgrading all other dependencies</releaseNotes>
 		<projectUrl>https://github.com/rongriffin/MassTransit.Host.RabbitMQ</projectUrl>
 		<copyright>Copyright 2014</copyright>
 		<tags>MassTransit host RabbitMQ</tags>
-		<dependencies>			
-			<dependency id="Castle.Core" version="3.2.0"/>
-			<dependency id="Castle.Windsor" version="3.2.0"/>
-			<dependency id="Magnum" version="2.1.2"/>
-			<dependency id="MassTransit" version="2.9.5"/>
-			<dependency id="MassTransit.CastleWindsor" version="2.9.5" />
-			<dependency id="MassTransit.RabbitMQ" version="2.9.5" />
-			<dependency id="Newtonsoft.Json" version="5.0.8"  />
-			<dependency id="RabbitMQ.Client" version="3.1.2"  />
-			<dependency id="Topshelf" version="3.1.3" />
-			<dependency id="NLog" version="3.1.0.0"/>
+		<dependencies>
+			<dependency id="Castle.Core" version="3.3.3"/>
+			<dependency id="Castle.Windsor" version="3.3.0"/>
+			<dependency id="Magnum" version="2.1.3"/>
+			<dependency id="MassTransit" version="3.3.5"/>
+			<dependency id="MassTransit.CastleWindsor" version="3.3.5" />
+			<dependency id="MassTransit.RabbitMQ" version="3.3.5" />
+			<dependency id="Newtonsoft.Json" version="7.0.1"  />
+			<dependency id="RabbitMQ.Client" version="3.6.2"  />
+			<dependency id="Topshelf" version="4.0.1" />
+			<dependency id="NLog" version="4.3.5"/>
 		</dependencies>
 	</metadata>
 	<files>

--- a/MassTransit.Host.RabbitMQ/NugetFiles/MassTransit.Host.RabbitMQ.exe.config.transform
+++ b/MassTransit.Host.RabbitMQ/NugetFiles/MassTransit.Host.RabbitMQ.exe.config.transform
@@ -1,5 +1,5 @@
 ﻿<configuration>
 	<connectionStrings>
-		<add name="Host.RabbitMQConnection" connectionString="endpoint=rabbitmq://RABBITMQ_SERVER/RABBITMQ_ENDPOINT_QUEUE; userId=guest; password=guest" />
+		<add name="Host.RabbitMQConnection" connectionString="endpoint=rabbitmq://RABBITMQ_SERVER/OPTIONAL_VHOST; queueName=rabbitmq_test_queue; userId=guest; password=guest" />
 	</connectionStrings>
 </configuration>

--- a/MassTransit.Host.RabbitMQ/packages.config
+++ b/MassTransit.Host.RabbitMQ/packages.config
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.2.0" targetFramework="net45" />
-  <package id="Castle.Windsor" version="3.2.1" targetFramework="net45" />
-  <package id="Magnum" version="2.1.2" targetFramework="net45" />
-  <package id="MassTransit" version="2.9.5" targetFramework="net45" />
-  <package id="MassTransit.CastleWindsor" version="2.9.5" targetFramework="net45" />
-  <package id="MassTransit.RabbitMQ" version="2.9.5" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
-  <package id="NLog" version="3.1.0.0" targetFramework="net45" />
-  <package id="RabbitMQ.Client" version="3.2.1" targetFramework="net45" />
-  <package id="Topshelf" version="3.1.3" targetFramework="net45" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Castle.Windsor" version="3.3.0" targetFramework="net452" />
+  <package id="Magnum" version="2.1.3" targetFramework="net452" />
+  <package id="MassTransit" version="3.3.5" targetFramework="net452" />
+  <package id="MassTransit.CastleWindsor" version="3.3.5" targetFramework="net452" />
+  <package id="MassTransit.RabbitMQ" version="3.3.5" targetFramework="net452" />
+  <package id="NewId" version="2.1.3" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="NLog" version="4.3.5" targetFramework="net452" />
+  <package id="RabbitMQ.Client" version="3.6.2" targetFramework="net452" />
+  <package id="Topshelf" version="4.0.1" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MassTransit.Host.RabbitMQ #
 
-A service host process for MassTransit consumer services using RabbitMQ for transport.  **Currently not compatible with MassTransit 3.0 and later.**
+A service host process for MassTransit consumer services using RabbitMQ for transport.
 
 **Apache License, Version 2.0:** [http://www.apache.org/licenses/LICENSE-2.0.html](http://www.apache.org/licenses/LICENSE-2.0.html)
 


### PR DESCRIPTION
Masstransit 3 now supported and all additional dependencies also updated. There is also a slight change in the connectionString (new key/value pair for queueName).

Pre-MassTransit 3 upgrade:
`<add name="Host.RabbitMQConnection" connectionString="endpoint=rabbitmq://RABBITMQ_SERVER/RABBITMQ_ENDPOINT_QUEUE; userId=guest; password=guest" />`

With MassTransit 3:
`<add name="Host.RabbitMQConnection" connectionString="endpoint=rabbitmq://RABBITMQ_SERVER/OPTIONAL_VHOST; queueName=rabbitmq_test_queue; userId=guest; password=guest" />`

The primary reason for doing this is because now when connecting to a host endpoint, the queue name is not a part of that endpoint. Only the rabbimq server, and optionally, a virtual host. So now we will have code that looks like the following (queue name is a separate parameter):

`busControl.ReceiveEndpoint(host, busConfig.QueueName, x => x.LoadFrom(container));`
