### PR TITLE
Upgrade to MassTransit v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+.vs/
 
 # Build results
 [Dd]ebug/

--- a/MassTransit.Host.RabbitMQ.Tests/App.config
+++ b/MassTransit.Host.RabbitMQ.Tests/App.config
@@ -7,11 +7,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="RabbitMQ.Client" publicKeyToken="89e7d7c5feba84ce" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.6.3.0" newVersion="3.6.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="MassTransit" publicKeyToken="b8e0e9f2f1e657fa" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.1.0.1516" newVersion="5.1.0.1516" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/MassTransit.Host.RabbitMQ/MassTransit.Host.RabbitMQ.csproj
+++ b/MassTransit.Host.RabbitMQ/MassTransit.Host.RabbitMQ.csproj
@@ -43,41 +43,49 @@
       <HintPath>..\packages\Castle.Windsor.3.3.0\lib\net45\Castle.Windsor.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="GreenPipes, Version=2.1.0.106, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\GreenPipes.2.1.0\lib\net452\GreenPipes.dll</HintPath>
+    </Reference>
     <Reference Include="Magnum, Version=2.1.3.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
       <HintPath>..\packages\Magnum.2.1.3\lib\NET40\Magnum.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MassTransit, Version=3.3.1.0, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
-      <HintPath>..\packages\MassTransit.3.3.5\lib\net452\MassTransit.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MassTransit, Version=5.1.0.1516, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
+      <HintPath>..\packages\MassTransit.5.1.0\lib\net452\MassTransit.dll</HintPath>
     </Reference>
-    <Reference Include="MassTransit.RabbitMqTransport, Version=3.3.1.0, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
-      <HintPath>..\packages\MassTransit.RabbitMQ.3.3.5\lib\net452\MassTransit.RabbitMqTransport.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MassTransit.RabbitMqTransport, Version=5.1.0.1516, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
+      <HintPath>..\packages\MassTransit.RabbitMQ.5.1.0\lib\net452\MassTransit.RabbitMqTransport.dll</HintPath>
     </Reference>
     <Reference Include="MassTransit.WindsorIntegration, Version=3.3.1.0, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
       <HintPath>..\packages\MassTransit.CastleWindsor.3.3.5\lib\net452\MassTransit.WindsorIntegration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NewId, Version=2.1.3.0, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
-      <HintPath>..\packages\NewId.2.1.3\lib\net45\NewId.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.28\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NewId, Version=3.0.1.17, Culture=neutral, PublicKeyToken=b8e0e9f2f1e657fa, processorArchitecture=MSIL">
+      <HintPath>..\packages\NewId.3.0.1\lib\net452\NewId.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json.Bson, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.Bson.1.0.1\lib\net45\Newtonsoft.Json.Bson.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.3.5\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.6.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\packages\RabbitMQ.Client.3.6.2\lib\net45\RabbitMQ.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="RabbitMQ.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\packages\RabbitMQ.Client.5.0.1\lib\net451\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/MassTransit.Host.RabbitMQ/MassTransit.Host.RabbitMQ.nuspec
+++ b/MassTransit.Host.RabbitMQ/MassTransit.Host.RabbitMQ.nuspec
@@ -2,28 +2,34 @@
 <package >
 	<metadata>
 		<id>MassTransit.Host.RabbitMQ</id>
-		<version>2.0.4</version>
+		<version>3.0.0</version>
 		<title>MassTransit.Host.RabbitMQ</title>
 		<authors>Ron Griffin</authors>
 		<owners>rongriffin@gmail.com</owners>
 		<licenseUrl>http://www.apache.org/licenses/LICENSE-2.0.html</licenseUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>Service Bus Host for Mass Transit services using RabbitMQ</description>
-		<releaseNotes>Explicitly restore the MT 2 behavior of 5 immediate retries.</releaseNotes>
+		<releaseNotes>Upgrade to MassTransit v5</releaseNotes>
 		<projectUrl>https://github.com/rongriffin/MassTransit.Host.RabbitMQ</projectUrl>
 		<copyright>Copyright 2014</copyright>
 		<tags>MassTransit host RabbitMQ</tags>
 		<dependencies>
 			<dependency id="Castle.Core" version="3.3.3"/>
 			<dependency id="Castle.Windsor" version="3.3.0"/>
+			<dependency id="GreenPipes" version="2.1.0"/>
 			<dependency id="Magnum" version="2.1.3"/>
-			<dependency id="MassTransit" version="3.3.5"/>
+			<dependency id="MassTransit" version="5.1.0"/>
 			<dependency id="MassTransit.CastleWindsor" version="3.3.5" />
-			<dependency id="MassTransit.RabbitMQ" version="3.3.5" />
-			<dependency id="Newtonsoft.Json" version="7.0.1"  />
-			<dependency id="RabbitMQ.Client" version="3.6.2"  />
-			<dependency id="Topshelf" version="4.0.1" />
+			<dependency id="MassTransit.RabbitMQ" version="5.1.0" />
+			<dependency id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28"/>
+			<dependency id="NewId" version="3.0.1"/>
+			<dependency id="Newtonsoft.Json" version="11.0.2"  />
+			<dependency id="Newtonsoft.Json.Bson" version="1.0.1"/>
 			<dependency id="NLog" version="4.3.5"/>
+			<dependency id="RabbitMQ.Client" version="5.0.1"  />
+			<dependency id="System.Reflection.Emit.Lightweight" version="4.3.0"/>
+			<dependency id="System.ValueTuple" version="4.4.0"/>
+			<dependency id="Topshelf" version="4.0.1" />
 		</dependencies>
 	</metadata>
 	<files>

--- a/MassTransit.Host.RabbitMQ/packages.config
+++ b/MassTransit.Host.RabbitMQ/packages.config
@@ -2,13 +2,18 @@
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
   <package id="Castle.Windsor" version="3.3.0" targetFramework="net452" />
+  <package id="GreenPipes" version="2.1.0" targetFramework="net452" />
   <package id="Magnum" version="2.1.3" targetFramework="net452" />
-  <package id="MassTransit" version="3.3.5" targetFramework="net452" />
+  <package id="MassTransit" version="5.1.0" targetFramework="net452" />
   <package id="MassTransit.CastleWindsor" version="3.3.5" targetFramework="net452" />
-  <package id="MassTransit.RabbitMQ" version="3.3.5" targetFramework="net452" />
-  <package id="NewId" version="2.1.3" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="MassTransit.RabbitMQ" version="5.1.0" targetFramework="net452" />
+  <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net452" />
+  <package id="NewId" version="3.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json.Bson" version="1.0.1" targetFramework="net452" />
   <package id="NLog" version="4.3.5" targetFramework="net452" />
-  <package id="RabbitMQ.Client" version="3.6.2" targetFramework="net452" />
+  <package id="RabbitMQ.Client" version="5.0.1" targetFramework="net452" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
   <package id="Topshelf" version="4.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Upgrading from MassTransit 3.x to 5.x. The only breaking change appears to have been in the configuration of retries.